### PR TITLE
Simple without reward token

### DIFF
--- a/contracts/sktl.sol
+++ b/contracts/sktl.sol
@@ -110,12 +110,13 @@ contract SKTL is
     }
 
     function increaseReward(uint256 amount) public onlyOwner {
-        _mint(owner(), amount);
+        uint256 beforeSupply = totalSupply();
+        _mint(owner(), amount); // mint only if it's not over the cap
 
         // scale the deposit and add the previous remainder
         uint256 scaledAvailable = (amount * scaling) + _scaledRemainder;
-        _scaledRewardPerToken += scaledAvailable / totalSupply();
-        _scaledRemainder = scaledAvailable % totalSupply();
+        _scaledRewardPerToken += scaledAvailable / beforeSupply;
+        _scaledRemainder = scaledAvailable % beforeSupply;
         _scaledRewardCreditedTo[owner()] = _scaledRewardPerToken;
     }
 

--- a/contracts/sktl.sol
+++ b/contracts/sktl.sol
@@ -17,14 +17,9 @@ contract SKTL is
     ERC20Pausable,
     ERC20Capped
 {
-    uint256 public constant scaling = 10**10; // make sure rewards * scaling is still less than 2^256
-
-    // 3B fixed, to calculate the weight to payout rewards, set the accomodate the future max tokens
-    // uint256 public constant totalRewardToken = 3000 * 10**6 * 10**18;
-
+    uint256 public constant scaling = 10**18; // make sure rewards * scaling is still less than 2^256
     uint256 private _scaledRewardPerToken = 0;
     mapping(address => uint256) private _scaledRewardCreditedTo;
-    // mapping(address => uint256) private _rewardTokenBalance;
     uint256 private _scaledRemainder = 0;
     bool private _transferHookEnabled = true;
 
@@ -40,7 +35,6 @@ contract SKTL is
 
         // owner() will own the unclaimed tokens
         _mint(owner(), 200000000000000000000000000); // initial 200MM supply
-        // _rewardTokenBalance[owner()] = totalRewardToken;
     }
 
     function rewardBalance(address account)
@@ -81,9 +75,6 @@ contract SKTL is
         _transferHookEnabled = false;
         _transfer(owner(), newOwner, balanceOf(owner()));
         _transferHookEnabled = true;
-
-        // _rewardTokenBalance[newOwner] = _rewardTokenBalance[owner()];
-        // _rewardTokenBalance[owner()] = 0;
         _scaledRewardCreditedTo[newOwner] = _scaledRewardPerToken;
 
         super.transferOwnership(newOwner);
@@ -116,12 +107,6 @@ contract SKTL is
         if (from == address(0))
             // minting
             return;
-
-        // uint256 rewardTokenTransfered = (value * totalRewardToken) /
-        //     totalSupply();
-
-        // _rewardTokenBalance[from] -= rewardTokenTransfered;
-        // _rewardTokenBalance[to] += rewardTokenTransfered;
     }
 
     function increaseReward(uint256 amount) public onlyOwner {
@@ -138,15 +123,6 @@ contract SKTL is
         require(rewardBalance(_msgSender()) > 0, "No rewards left to withdraw");
         _update(_msgSender());
     }
-
-    // function rewardTokenBalance(address addr)
-    //     public
-    //     view
-    //     virtual
-    //     returns (uint256)
-    // {
-    //     return _rewardTokenBalance[addr];
-    // }
 
     function _mint(address account, uint256 amount)
         internal

--- a/tests/test_sktl.py
+++ b/tests/test_sktl.py
@@ -62,29 +62,6 @@ class TestSKTLSimpleDvd(unittest.TestCase):
             "original donation pool balance failed after init transfer",
         )
 
-    def test_init_reward_tokens(self):
-        # check the rewardToken
-        total_reward_token = self.token.totalRewardToken()
-        half_token = int(total_reward_token / 2)
-
-        self.assertEqual(
-            int(
-                self.token.rewardTokenBalance(get_account(self.dontation_pool_acc))
-                / DECIMALS
-            ),
-            int(half_token / DECIMALS),
-            "Donation pool doesn't have half rewardToken",
-        )
-
-        for i in range(1, len(self.init_acc_tokens)):
-            self.assertEqual(
-                int(self.token.rewardTokenBalance(get_account(i))),
-                int(
-                    ((self.init_acc_tokens[i] * total_reward_token) // self.init_token)
-                ),
-                msg=f"account[{i}] rewardbalance doesn't match",
-            )
-
     def test_simple_rewards(self):
         rewards = 10000
         self.token.increaseReward(rewards * DECIMALS)
@@ -112,6 +89,7 @@ class TestSKTLSimpleDvd(unittest.TestCase):
                 self.token.rewardBalance(get_account(i)),
                 int((rewards * self.init_acc_tokens[i] * DECIMALS) // self.init_token),
                 f"account[{i}] reward balance doesn't match",
+                5,
             )
 
     def test_second_rewards(self):
@@ -144,6 +122,7 @@ class TestSKTLSimpleDvd(unittest.TestCase):
                     / self.init_token
                 ),
                 f"account[{i}] reward balance doesn't match after multiple rewards",
+                4,
             )
 
     def test_transfer_after_rewards(self):
@@ -169,12 +148,10 @@ class TestSKTLSimpleDvd(unittest.TestCase):
         ) + transfer
 
         self.assertIntAlmostEqual(
-            self.token.balanceOf(get_account(2)),
-            balance2 * DECIMALS,
+            self.token.balanceOf(get_account(2)), balance2 * DECIMALS, "", 4
         )
         self.assertIntAlmostEqual(
-            self.token.balanceOf(get_account(3)),
-            balance3 * DECIMALS,
+            self.token.balanceOf(get_account(3)), balance3 * DECIMALS, "", 4
         )
 
     def test_should_fail(self):


### PR DESCRIPTION
Avoid using RewardToken
so far the precision seems to get hit (more rounding error)

For example, this unittest is failing

```
brownie compile && brownie test tests/test_sktl.py::TestSKTLSimpleDvd::test_simple_rewards --verbose
```